### PR TITLE
Add link to registration page in short courses

### DIFF
--- a/_includes/about-short-courses.html
+++ b/_includes/about-short-courses.html
@@ -14,7 +14,7 @@
                     <p><b>Instructor(s):</b> {{ row.instructors }}</p>
                     <p><b>Time:</b> {{ row.time }}</p>
                     <p>{{ row.details }}</p>
-                    <p><b>Cost:</b> ${{ row.cost }} Seats are limited. One may add this short course to his/her registration at any time via the registration form (link to the registration page).</p>
+                    <p><b>Cost:</b> ${{ row.cost }}. Seats are limited. One may add this short course to his/her registration at any time via the <a href="{{ site.baseurl }}/registration/">registration form</a>.</p>
                 </div>
             </div>
             {% endfor %}


### PR DESCRIPTION
Change short courses to link to the `/registration` page (instead of text that says "Link to Registration Page")

Before:
![image](https://user-images.githubusercontent.com/12307910/72687663-219f8d80-3ace-11ea-9f59-dce5c481b550.png)

After:
![image](https://user-images.githubusercontent.com/12307910/72687650-f7e66680-3acd-11ea-9d2e-635cbe4fbbed.png)
